### PR TITLE
use correct unit for vanilla chunk timestamps

### DIFF
--- a/src/main/java/cubicchunks/regionlib/impl/save/MinecraftSaveSection.java
+++ b/src/main/java/cubicchunks/regionlib/impl/save/MinecraftSaveSection.java
@@ -54,7 +54,7 @@ public class MinecraftSaveSection extends SaveSection<MinecraftSaveSection, Mine
 								.setSectorSize(4096)
 								.setKeyProvider(keyProvider)
 								.setRegionKey(regionKey)
-								.addHeaderEntry(new TimestampHeaderEntryProvider<>(TimeUnit.MILLISECONDS))
+								.addHeaderEntry(new TimestampHeaderEntryProvider<>(TimeUnit.SECONDS))
 								.build(),
 						(dir, key) -> Files.exists(dir.resolve(key.getRegionKey().getName()))
 				)


### PR DESCRIPTION
vanilla anvil regions' timestamps are in seconds, not milliseconds.